### PR TITLE
Don't use lret to accumulate.

### DIFF
--- a/src.lisp
+++ b/src.lisp
@@ -88,12 +88,13 @@ VERTICES and whose values are lists of vertices."
 (defun map-edges (function graph)
   "Returns a list of the results of calling FUNCTION on each edge of GRAPH.
 FUNCTION should take 2 arguments: the starting and ending vertices of an edge."
-  (lret ((result (list)))
+  (let ((result (list)))
     (maphash (lambda (k v)
                (mapc (lambda (x)
                        (push (funcall function k x) result))
                      v))
-             (edges graph))))
+             (edges graph))
+    result))
 ;;; BUG: ordered mapping causes an infinite loop on cycles
 (defmacro traverse (&body body)
   `(progn (cond ((member vertex seen :test #'equal))


### PR DESCRIPTION
The `lret` utility returns the initial value of its binding, not the value at the end of the form, which means `map-edges`, as written, always returns nil. This pull request fixes that by replacing `lret` with an ordinary `let`.

The latest version of Serapeum makes it a compile-time error to try to set the variable, to prevent exactly this misunderstanding, which unfortunately means that `cl-directed-graph` is currently broken in Quicklisp.